### PR TITLE
Update WebSockets URL

### DIFF
--- a/lib/main.jsx
+++ b/lib/main.jsx
@@ -7,7 +7,7 @@ import notie from 'notie';
 const options = {
     apis: ["database_api", "network_broadcast_api"],
     // url: "wss://node.steem.ws"
-    url: "wss://steemit.com:443/wspa"
+    url: "wss://steemd.steemit.com"
 };
 
 


### PR DESCRIPTION
It used to use the old Steemit WebSockets URL, this updates it.